### PR TITLE
Changed mountains of Tectonic

### DIFF
--- a/data/tectonic/worldgen/density_function/hbridges/noiseshift/base.json
+++ b/data/tectonic/worldgen/density_function/hbridges/noiseshift/base.json
@@ -1,0 +1,6 @@
+{
+  "type": "minecraft:noise",
+  "noise": "tectonic:hbridges/base",
+  "xz_scale": 1.7,
+  "y_scale": 1
+}

--- a/data/tectonic/worldgen/density_function/hbridges/noiseshift/shiftx.json
+++ b/data/tectonic/worldgen/density_function/hbridges/noiseshift/shiftx.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:shifted_noise",
+  "noise": "tectonic:hbridges/base",
+  "xz_scale": 1.7,
+  "y_scale": 1,
+  "shift_x": 10,
+  "shift_y": 0,
+  "shift_z": 0
+}

--- a/data/tectonic/worldgen/density_function/hbridges/noiseshift/shiftz.json
+++ b/data/tectonic/worldgen/density_function/hbridges/noiseshift/shiftz.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:shifted_noise",
+  "noise": "tectonic:hbridges/base",
+  "xz_scale": 1.7,
+  "y_scale": 1,
+  "shift_x": 0,
+  "shift_y": 0,
+  "shift_z": 10
+}

--- a/data/tectonic/worldgen/density_function/hbridges/noiseshift/slopex.json
+++ b/data/tectonic/worldgen/density_function/hbridges/noiseshift/slopex.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:add",
+  "argument1": "tectonic:hbridges/noiseshift/base",
+  "argument2": {
+    "type": "minecraft:mul",
+    "argument1": -1,
+    "argument2": "tectonic:hbridges/noiseshift/shiftx"
+  }
+}

--- a/data/tectonic/worldgen/density_function/hbridges/noiseshift/slopez.json
+++ b/data/tectonic/worldgen/density_function/hbridges/noiseshift/slopez.json
@@ -1,0 +1,9 @@
+{
+  "type": "minecraft:add",
+  "argument1": "tectonic:hbridges/noiseshift/base",
+  "argument2": {
+    "type": "minecraft:mul",
+    "argument1": -1,
+    "argument2": "tectonic:hbridges/noiseshift/shiftz"
+  }
+}

--- a/data/tectonic/worldgen/density_function/hbridges/ridges.json
+++ b/data/tectonic/worldgen/density_function/hbridges/ridges.json
@@ -1,0 +1,15 @@
+{
+  "type": "minecraft:flat_cache",
+  "argument": {
+    "type": "minecraft:cache_2d",
+    "argument": {
+      "type": "minecraft:add",
+      "argument1": "tectonic:hbridges/noiseshift/base",
+      "argument2": {
+        "type": "minecraft:mul",
+        "argument1": 0.6,
+        "argument2": "tectonic:hbridges/shifteddetail"
+      }
+    }
+  }
+}

--- a/data/tectonic/worldgen/density_function/hbridges/shifteddetail.json
+++ b/data/tectonic/worldgen/density_function/hbridges/shifteddetail.json
@@ -1,0 +1,23 @@
+{
+  "type": "minecraft:shifted_noise",
+  "noise": "tectonic:hbridges/detailed",
+  "xz_scale": 2,
+  "y_scale": 0,
+  "shift_x": {
+    "type": "minecraft:mul",
+    "argument1": {
+      "type": "minecraft:abs",
+      "argument": "tectonic:hbridges/noiseshift/slopex"
+    },
+    "argument2": 3000
+  },
+  "shift_y": 0,
+  "shift_z": {
+    "type": "minecraft:mul",
+    "argument1": {
+      "type": "minecraft:abs",
+      "argument": "tectonic:hbridges/noiseshift/slopez"
+    },
+    "argument2": 3000
+  }
+}

--- a/data/tectonic/worldgen/density_function/hbridges/weathering.json
+++ b/data/tectonic/worldgen/density_function/hbridges/weathering.json
@@ -1,0 +1,39 @@
+{
+  "type": "minecraft:add",
+  "argument1": 1,
+  "argument2": {
+    "type": "minecraft:mul",
+    "argument1": -1,
+    "argument2": {
+      "type": "minecraft:clamp",
+      "input": {
+        "type": "minecraft:spline",
+        "spline": {
+          "coordinate": {
+            "type": "minecraft:abs",
+            "argument": {
+              "type": "minecraft:noise",
+              "noise": "tectonic:hbridges/weathering",
+              "xz_scale": 2.5,
+              "y_scale": 2
+            }
+          },
+          "points": [
+            {
+              "location": 0.025,
+              "derivative": 20,
+              "value": 0
+            },
+            {
+              "location": 1,
+              "derivative": 0,
+              "value": 1
+            }
+          ]
+        }
+      },
+      "min": 0,
+      "max": 1
+    }
+  }
+}

--- a/data/tectonic/worldgen/density_function/overworld/sloped_cheese.json
+++ b/data/tectonic/worldgen/density_function/overworld/sloped_cheese.json
@@ -29,22 +29,22 @@
         "argument2": {
           "type": "minecraft:add",
           "argument1": {
-            "type": "minecraft:quarter_negative",
-            "argument": {
-              "type": "minecraft:add",
-              "argument1": {
-                "type": "minecraft:abs",
-                "argument": {
-                  "type": "minecraft:noise",
-                  "noise": "minecraft:jagged",
-                  "xz_scale": 1500,
-                  "y_scale": 0
-                }
-              },
-              "argument2": -0.25
-            }
+            "type": "minecraft:mul",
+            "argument1": -0.1,
+            "argument2": "tectonic:hbridges/weathering"
           },
-          "argument2": 0.2
+          "argument2": {
+            "type": "minecraft:add",
+            "argument1": {
+              "type": "minecraft:flat_cache",
+              "argument": {
+                "type": "minecraft:mul",
+                "argument1": "tectonic:hbridges/ridges",
+                "argument2": -1
+              }
+            },
+            "argument2": 0.6
+          }
         }
       }
     }

--- a/data/tectonic/worldgen/noise/hbridges/base.json
+++ b/data/tectonic/worldgen/noise/hbridges/base.json
@@ -1,0 +1,7 @@
+{
+  "firstOctave": -8,
+  "amplitudes": [
+    1,
+    0.2
+  ]
+}

--- a/data/tectonic/worldgen/noise/hbridges/detailed.json
+++ b/data/tectonic/worldgen/noise/hbridges/detailed.json
@@ -1,0 +1,7 @@
+{
+  "firstOctave": -7,
+  "amplitudes": [
+    0.2,
+    1
+  ]
+}

--- a/data/tectonic/worldgen/noise/hbridges/weathering.json
+++ b/data/tectonic/worldgen/noise/hbridges/weathering.json
@@ -1,0 +1,7 @@
+{
+  "firstOctave": -4,
+  "amplitudes": [
+    1,
+    0
+  ]
+}


### PR DESCRIPTION
As we had already talked about on Discord, here's the pull request for my improved mountains. 
# Changes made
I touched sloped_cheese.json and added my own files.
# How it works
I take a low resolution noise (``hbridges/base``) and shift it by 10 units in x and z direction. Then I subtract the noise sampled at each shifted position from the base, which gives me the (approximate) slopes in x and z direction. I can then use a higher detail noise (``hbridges/detailed``) and sample it as shifted_noise with the shift amount being the slope in that area. That looks something like this:
![image](https://github.com/Apollounknowndev/tectonic/assets/56313836/f070abdd-4289-41ef-a3a5-177d9f6dbb37)
If we then add this noise (with a multiplier of .6) to our base noise, we get this:
![image](https://github.com/Apollounknowndev/tectonic/assets/56313836/7906c69c-abac-4e18-bf27-45420f22eb3d)
Fake perlin mountains with somewhat believable "water" channels running down the slopes. Using pure perlin noise with no modifications as the base is the most efficient here, but certainly not the best approach in general. This could potentially still be improved to get a better mountain base shape before applying the water channels. However all work processing mountains would have to be done three times as we can only shift noise, not density functions.
Finally, another stage of weathering is applied. We use a very high base octave (read: very small) noise, and take the absolute. This gives us nice lines like the ones used for the mountain ridge generation in tectonic. We then sharpen the valley with a spline. I was lazy here and just clamped the value of the spline between 0 and 1 as it otherwise would shoot up to 10 or so from how steep it is. We do not flat_cache the weathering, so it remains 3d and cut through the terrain in 3d. Interesting things happen if one cranks up the multiplier for weathering. The resulting DF looks like this:
![image](https://github.com/Apollounknowndev/tectonic/assets/56313836/a46d7853-43a2-47b9-ae61-95bff2748cd7)
in sloped_cheese we now replace the section that lies below the multiplier with jaggedness, in other words the part of the world affected by the mountains. Here we apply the mountain height map with some multipliers, then cut into the surface layer of the depth map with our weathering. That's all I have modified. 
Now, here are some
# Screenshots
(using modified terralith (removed fantasy biomes), modified terratonic (my mountains) and geophilic)
![2024-01-08_18 41 54](https://github.com/Apollounknowndev/tectonic/assets/56313836/67e9f508-53a5-4d88-9d6a-76ef1fae0d26)
![2024-01-08_20 49 46](https://github.com/Apollounknowndev/tectonic/assets/56313836/8b3ed248-bd3d-4af5-9c3f-997f69906d69)
![2024-01-09_14 42 02](https://github.com/Apollounknowndev/tectonic/assets/56313836/6aeb171b-741c-414a-be30-231208bb951f)
![2024-01-10_20 54 56](https://github.com/Apollounknowndev/tectonic/assets/56313836/1062e8af-5f5d-404d-80ed-4e4d1ca75ae5)
![2024-01-10_20 55 16](https://github.com/Apollounknowndev/tectonic/assets/56313836/3f6ff636-56a9-40d5-b22f-b7b658af3158)
![2024-01-10_20 55 27](https://github.com/Apollounknowndev/tectonic/assets/56313836/ffad734b-d42c-470c-8035-d88bfccc5e51)
![2024-01-10_20 55 39](https://github.com/Apollounknowndev/tectonic/assets/56313836/f19dee1c-a98f-4977-b934-79ab82754ca8)
Feel free to use any of these screenshots on the tectonic modrinth page or wherever you see fit. I would appreciate credit for the work I've done with the datapack. 

# Terratonic 
This is not applied to terratonic, but it should be relatively simple to do so. The only file I touched which originates from tectonic is sloped_cheese. Last time I moved my changes into tectonic I had to edit the sloped_cheese file a bit as a few noises were not in tectonic, but in minecraft.